### PR TITLE
Fix: Update repository links to ReallyArtificial org

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/josharsh/mcp-jest/blob/main/CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/ReallyArtificial/mcp-jest/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions & Discussions
-    url: https://github.com/josharsh/mcp-jest/discussions
+    url: https://github.com/ReallyArtificial/mcp-jest/discussions
     about: Please ask and answer questions here
   - name: Documentation
-    url: https://github.com/josharsh/mcp-jest/tree/main/docs
+    url: https://github.com/ReallyArtificial/mcp-jest/tree/main/docs
     about: Check out our documentation for usage guides
   - name: Security Issues
-    url: https://github.com/josharsh/mcp-jest/security/policy
+    url: https://github.com/ReallyArtificial/mcp-jest/security/policy
     about: Please report security vulnerabilities here

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -50,7 +50,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/josharsh/mcp-jest/blob/main/CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/ReallyArtificial/mcp-jest/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,15 +125,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Simple test configuration format
 - Connection and capability testing
 
-[Unreleased]: https://github.com/josharsh/mcp-jest/compare/v1.0.13...HEAD
-[1.0.13]: https://github.com/josharsh/mcp-jest/compare/v1.0.10...v1.0.13
-[1.0.10]: https://github.com/josharsh/mcp-jest/compare/v1.0.8...v1.0.10
-[1.0.8]: https://github.com/josharsh/mcp-jest/compare/v1.0.7...v1.0.8
-[1.0.7]: https://github.com/josharsh/mcp-jest/compare/v1.0.6...v1.0.7
-[1.0.6]: https://github.com/josharsh/mcp-jest/compare/v1.0.5...v1.0.6
-[1.0.5]: https://github.com/josharsh/mcp-jest/compare/v1.0.4...v1.0.5
-[1.0.4]: https://github.com/josharsh/mcp-jest/compare/v1.0.3...v1.0.4
-[1.0.3]: https://github.com/josharsh/mcp-jest/compare/v1.0.2...v1.0.3
-[1.0.2]: https://github.com/josharsh/mcp-jest/compare/v1.0.1...v1.0.2
-[1.0.1]: https://github.com/josharsh/mcp-jest/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/josharsh/mcp-jest/releases/tag/v1.0.0
+[Unreleased]: https://github.com/ReallyArtificial/mcp-jest/compare/v1.0.13...HEAD
+[1.0.13]: https://github.com/ReallyArtificial/mcp-jest/compare/v1.0.10...v1.0.13
+[1.0.10]: https://github.com/ReallyArtificial/mcp-jest/compare/v1.0.8...v1.0.10
+[1.0.8]: https://github.com/ReallyArtificial/mcp-jest/compare/v1.0.7...v1.0.8
+[1.0.7]: https://github.com/ReallyArtificial/mcp-jest/compare/v1.0.6...v1.0.7
+[1.0.6]: https://github.com/ReallyArtificial/mcp-jest/compare/v1.0.5...v1.0.6
+[1.0.5]: https://github.com/ReallyArtificial/mcp-jest/compare/v1.0.4...v1.0.5
+[1.0.4]: https://github.com/ReallyArtificial/mcp-jest/compare/v1.0.3...v1.0.4
+[1.0.3]: https://github.com/ReallyArtificial/mcp-jest/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/ReallyArtificial/mcp-jest/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/ReallyArtificial/mcp-jest/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/ReallyArtificial/mcp-jest/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ We use GitHub to host code, to track issues and feature requests, as well as acc
 
 2. **Setup**
    ```bash
-   git clone https://github.com/josharsh/mcp-jest.git
+   git clone https://github.com/ReallyArtificial/mcp-jest.git
    cd mcp-jest
    npm install
    ```
@@ -148,7 +148,7 @@ describe('MCPTestRunner', () => {
 
 ## Reporting Bugs
 
-We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/josharsh/mcp-jest/issues).
+We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/ReallyArtificial/mcp-jest/issues).
 
 **Great Bug Reports** tend to have:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/mcp-jest.svg)](https://www.npmjs.com/package/mcp-jest)
 [![npm downloads](https://img.shields.io/npm/dm/mcp-jest.svg)](https://www.npmjs.com/package/mcp-jest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Node.js CI](https://github.com/josharsh/mcp-jest/actions/workflows/ci.yml/badge.svg)](https://github.com/josharsh/mcp-jest/actions/workflows/ci.yml)
+[![Node.js CI](https://github.com/ReallyArtificial/mcp-jest/actions/workflows/ci.yml/badge.svg)](https://github.com/ReallyArtificial/mcp-jest/actions/workflows/ci.yml)
 [![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue.svg)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![MCP Compatible](https://img.shields.io/badge/MCP-Compatible-green.svg)](https://modelcontextprotocol.io)
@@ -161,7 +161,7 @@ See [CLI Reference](docs/cli-reference.md) for all options.
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ```bash
-git clone https://github.com/josharsh/mcp-jest.git
+git clone https://github.com/ReallyArtificial/mcp-jest.git
 cd mcp-jest
 npm install
 npm run dev
@@ -193,8 +193,8 @@ MCP-Jest is ideal for:
 
 ## Support
 
-- [GitHub Issues](https://github.com/josharsh/mcp-jest/issues) - Bug reports and feature requests
-- [GitHub Discussions](https://github.com/josharsh/mcp-jest/discussions) - Questions and ideas
+- [GitHub Issues](https://github.com/ReallyArtificial/mcp-jest/issues) - Bug reports and feature requests
+- [GitHub Discussions](https://github.com/ReallyArtificial/mcp-jest/discussions) - Questions and ideas
 - [Model Context Protocol](https://modelcontextprotocol.io) - Official MCP documentation
 
 ## Related Technologies

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ To report a security vulnerability, please use one of the following methods:
 ### 1. GitHub Security Advisories (Preferred)
 
 Report security vulnerabilities through GitHub's Security Advisory feature:
-1. Go to https://github.com/josharsh/mcp-jest/security/advisories
+1. Go to https://github.com/ReallyArtificial/mcp-jest/security/advisories
 2. Click "New draft security advisory"
 3. Fill in the details of your finding
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,8 +105,8 @@ mcp-jest --config mcp-jest.json
 
 ## Getting Help
 
-- **[GitHub Issues](https://github.com/josharsh/mcp-jest/issues)** - Bug reports
-- **[GitHub Discussions](https://github.com/josharsh/mcp-jest/discussions)** - Questions
+- **[GitHub Issues](https://github.com/ReallyArtificial/mcp-jest/issues)** - Bug reports
+- **[GitHub Discussions](https://github.com/ReallyArtificial/mcp-jest/discussions)** - Questions
 - **[Troubleshooting](guides/troubleshooting.md)** - Common issues
 
 ## Contributing

--- a/docs/guides/github-actions.md
+++ b/docs/guides/github-actions.md
@@ -49,7 +49,7 @@ jobs:
         run: npm ci
 
       - name: Test MCP Server
-        uses: josharsh/mcp-jest@v1
+        uses: ReallyArtificial/mcp-jest@v1
         with:
           server-command: 'node'
           server-args: 'dist/server.js'
@@ -168,7 +168,7 @@ jobs:
       - run: npm run build
 
       - name: Test MCP Server
-        uses: josharsh/mcp-jest@v1
+        uses: ReallyArtificial/mcp-jest@v1
         with:
           server-command: 'node'
           server-args: 'dist/server.js'

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -388,8 +388,8 @@ expect: (result) => {
 
 If you're still stuck:
 
-1. **Check existing issues**: [GitHub Issues](https://github.com/josharsh/mcp-jest/issues)
-2. **Ask a question**: [GitHub Discussions](https://github.com/josharsh/mcp-jest/discussions)
+1. **Check existing issues**: [GitHub Issues](https://github.com/ReallyArtificial/mcp-jest/issues)
+2. **Ask a question**: [GitHub Discussions](https://github.com/ReallyArtificial/mcp-jest/discussions)
 3. **File a bug report**: Include debug output, server info, and minimal reproduction
 
 When reporting issues, include:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -495,9 +495,9 @@ DEBUG=mcp-jest* mcp-jest node ./server.js --tools search
 
 ## Links
 
-- GitHub: https://github.com/josharsh/mcp-jest
+- GitHub: https://github.com/ReallyArtificial/mcp-jest
 - npm: https://www.npmjs.com/package/mcp-jest
-- Issues: https://github.com/josharsh/mcp-jest/issues
+- Issues: https://github.com/ReallyArtificial/mcp-jest/issues
 - MCP Specification: https://modelcontextprotocol.io
 
 ## License

--- a/llms.txt
+++ b/llms.txt
@@ -56,6 +56,6 @@ mcp-jest node ./server.js --tools search,email
 
 ## Links
 
-- [GitHub Repository](https://github.com/josharsh/mcp-jest)
+- [GitHub Repository](https://github.com/ReallyArtificial/mcp-jest)
 - [npm Package](https://www.npmjs.com/package/mcp-jest)
-- [Issue Tracker](https://github.com/josharsh/mcp-jest/issues)
+- [Issue Tracker](https://github.com/ReallyArtificial/mcp-jest/issues)

--- a/package.json
+++ b/package.json
@@ -69,16 +69,16 @@
   "author": "Harsh Joshi <harsh.joshi.pth@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/josharsh/mcp-jest.git"
+    "url": "git+https://github.com/ReallyArtificial/mcp-jest.git"
   },
   "bugs": {
-    "url": "https://github.com/josharsh/mcp-jest/issues"
+    "url": "https://github.com/ReallyArtificial/mcp-jest/issues"
   },
   "homepage": "https://mcp-jest.ddiy.diy",
   "license": "MIT",
   "funding": {
     "type": "github",
-    "url": "https://github.com/sponsors/josharsh"
+    "url": "https://github.com/sponsors/ReallyArtificial"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",


### PR DESCRIPTION
## Summary
The repository was transferred to ReallyArtificial org but README still referenced old josharsh URLs.

## Changes
- Updated CI badge links
- Updated git clone URL
- Updated Issues/Discussions links

All references now point to `ReallyArtificial/mcp-jest` instead of `josharsh/mcp-jest`.

## Context
Part of officially moving mcp-jest under Really Artificial organization branding.