### PR TITLE
docs: add TypeScript strict-mode example and README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,66 @@ See [CLI Reference](docs/cli-reference.md) for all options.
 - [GitHub Actions](docs/guides/github-actions.md)
 - [Watch Mode](docs/guides/watch-mode.md)
 
+## TypeScript Support
+
+mcp-jest ships full TypeScript definitions. The library itself is compiled with `"strict": true`, so all exported types are null-safe and carry no implicit `any`.
+
+### Using mcp-jest in a strict TypeScript project
+
+Add `"strict": true` to your `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}
+```
+
+Import the named types alongside the functions so the compiler can check your
+expectation callbacks:
+
+```typescript
+import {
+  mcpTest,
+  formatResults,
+  type MCPServerConfig,
+  type MCPTestConfig,
+} from 'mcp-jest';
+
+const server: MCPServerConfig = {
+  command: 'node',
+  args: ['./my-server.js'],
+};
+
+const config: MCPTestConfig = {
+  tools: {
+    search: {
+      args: { query: 'hello' },
+      // result is `unknown` — narrow before accessing properties
+      expect: (result: unknown): boolean => {
+        if (result === null || typeof result !== 'object') return false;
+        const r = result as Record<string, unknown>;
+        return Array.isArray(r['content']);
+      },
+    },
+  },
+};
+
+const results = await mcpTest(server, config);
+console.log(formatResults(results));
+```
+
+### Common strict-mode gotchas
+
+| Situation | Without strict | With strict |
+|---|---|---|
+| Expectation callback parameter | `(result) => …` silently typed as `any` | Must be `(result: unknown): boolean => …` |
+| Error handling in `catch` | `error.message` compiles | `error` is `unknown` — cast first: `(error as Error).message` |
+| Optional server fields | `env: undefined` compiles | Omit the key entirely — strict null checks flag the `undefined` assignment |
+
+See the full working example in [`examples/typescript-strict/`](examples/typescript-strict/).
+
 ## Requirements
 
 - **Node.js** 18+

--- a/examples/typescript-strict/strict-test.ts
+++ b/examples/typescript-strict/strict-test.ts
@@ -1,0 +1,90 @@
+/**
+ * TypeScript strict-mode example for mcp-jest.
+ *
+ * Strict mode enables a suite of type-safety checks that catch common bugs:
+ *   strictNullChecks  — variables can't be null/undefined unless declared so
+ *   noImplicitAny     — all variables must have explicit or inferred types
+ *   strictFunctionTypes — parameter types are checked contravariantly
+ *   ... and more (see https://www.typescriptlang.org/tsconfig#strict)
+ *
+ * Run: tsc --noEmit   (validates types without emitting JS)
+ * Run: node --loader ts-node/esm strict-test.ts  (execute with ts-node)
+ */
+
+import {
+  mcpTest,
+  formatResults,
+  type MCPServerConfig,
+  type MCPTestConfig,
+  type TestResults,
+} from 'mcp-jest';
+
+// ── Server configuration ────────────────────────────────────────────────────
+//
+// Strict gotcha #1: explicit types prevent `any` from slipping in through
+// object literals. Annotate MCPServerConfig directly instead of relying on
+// inference from an untyped literal.
+
+const server: MCPServerConfig = {
+  command: 'node',
+  args: ['./my-mcp-server.js'],
+  // env is optional — strict mode keeps it safely omitted (no `env: undefined`)
+};
+
+// ── Test configuration ──────────────────────────────────────────────────────
+//
+// Strict gotcha #2: expectation callbacks must declare parameter types.
+// Without strict mode `result` would silently be `any`; with strict mode you
+// must narrow it or assert the type.
+
+const config: MCPTestConfig = {
+  tools: {
+    search: {
+      args: { query: 'mcp-jest strict mode' },
+      // result is `unknown` here — narrow before accessing properties
+      expect: (result: unknown): boolean => {
+        if (result === null || typeof result !== 'object') return false;
+        const r = result as Record<string, unknown>;
+        return Array.isArray(r['content']) && (r['content'] as unknown[]).length > 0;
+      },
+    },
+    echo: {
+      args: { message: 'hello strict' },
+      // String-based expectations work fine in strict mode too
+      expect: 'success === true',
+    },
+  },
+  resources: {
+    'config.json': { expect: 'exists' },
+  },
+  timeout: 15_000,
+};
+
+// ── Main ────────────────────────────────────────────────────────────────────
+//
+// Strict gotcha #3: the return type of mcpTest is Promise<TestResults>.
+// Annotating it explicitly makes the linter warn if you accidentally ignore
+// the returned value.
+
+async function runStrictExample(): Promise<void> {
+  console.log('🔒 Running mcp-jest in TypeScript strict mode…\n');
+
+  // Strict gotcha #4: error handling — `error` in catch is `unknown`, not `Error`.
+  // Cast it explicitly before accessing `.message`.
+  let results: TestResults;
+  try {
+    results = await mcpTest(server, config);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('❌ Test runner threw an error:', message);
+    process.exit(1);
+  }
+
+  console.log(formatResults(results));
+
+  if (results.failed > 0) {
+    process.exit(1);
+  }
+}
+
+runStrictExample();

--- a/examples/typescript-strict/tsconfig.json
+++ b/examples/typescript-strict/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["./*.ts"]
+}


### PR DESCRIPTION
## Summary

Closes #48

Adds a worked TypeScript strict-mode example and a README section covering the most common strict-mode gotchas when using mcp-jest.

## Changes

### `examples/typescript-strict/tsconfig.json`
Minimal `tsconfig.json` with `"strict": true` (and `moduleResolution: "bundler"` to match modern Node/Bun projects).

### `examples/typescript-strict/strict-test.ts`
Annotated example that demonstrates the four common strict-mode pitfalls:

1. **Expectation callbacks** — `result` is `unknown`, not `any`. Must narrow before accessing properties.
2. **Unknown narrowing** — cast `result as Record<string, unknown>` inside a type-guard before indexing.
3. **Return type annotation** — annotate `mcpTest` result as `Promise<TestResults>` so the compiler catches ignored return values.
4. **Error handling** — `catch (err: unknown)` requires `err instanceof Error` check before `.message`.

### `README.md`
New **TypeScript Support** section with:
- Minimal tsconfig snippet
- Copy-pasteable strict-mode usage pattern
- Quick-reference table of gotchas (before / after strict mode)
- Link to the new example

## Testing

`tsc --noEmit` against `examples/typescript-strict/` compiles cleanly with strict mode.