### PR TITLE
test: add async tool handler example

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ See [CLI Reference](docs/cli-reference.md) for all options.
 - [GitHub Actions](docs/guides/github-actions.md)
 - [Watch Mode](docs/guides/watch-mode.md)
 
+### Runnable Examples
+
+- [Async tool handlers](examples/async-tools.test.ts) - test a tool that awaits a mocked async dependency and an expected async error path
+
 ## Requirements
 
 - **Node.js** 18+

--- a/examples/async-tools.test.ts
+++ b/examples/async-tools.test.ts
@@ -1,0 +1,104 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mcpTest } from '../src/index.js';
+
+const tempDir = join(process.cwd(), '.tmp-async-tools-example');
+const serverPath = join(tempDir, 'async-tools-server.mjs');
+
+const asyncServerSource = `
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+const profileApi = {
+  async fetchProfile(userId) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    if (userId === 'missing') {
+      throw new Error('profile not found');
+    }
+    return { id: userId, name: 'Ada Lovelace', plan: 'pro' };
+  }
+};
+
+const server = new McpServer({ name: 'async-tools-example', version: '1.0.0' });
+
+server.tool(
+  'get-profile',
+  { userId: z.string() },
+  async ({ userId }) => {
+    const profile = await profileApi.fetchProfile(userId);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(profile) }]
+    };
+  }
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+`;
+
+describe('async MCP tool handlers', () => {
+  beforeAll(async () => {
+    await mkdir(tempDir, { recursive: true });
+    await writeFile(serverPath, asyncServerSource, 'utf8');
+  });
+
+  afterAll(async () => {
+    await rm(tempDir, { force: true, recursive: true });
+  });
+
+  it('tests a tool handler that awaits a mocked async dependency', async () => {
+    const results = await mcpTest(
+      { command: 'node', args: [serverPath] },
+      {
+        tools: {
+          'get-profile': {
+            args: { userId: 'user-123' },
+            expect: (result) => {
+              const text = (result as { content: Array<{ text: string }> }).content[0].text;
+              const profile = JSON.parse(text);
+              return profile.id === 'user-123' && profile.name === 'Ada Lovelace' && profile.plan === 'pro';
+            }
+          }
+        },
+        timeout: 5000
+      }
+    );
+
+    expect(results.failed).toBe(0);
+    expect(results.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "Tool 'get-profile' execution",
+          status: 'pass'
+        })
+      ])
+    );
+  });
+
+  it('can assert that an async tool error is expected', async () => {
+    const results = await mcpTest(
+      { command: 'node', args: [serverPath] },
+      {
+        tools: {
+          'get-profile:missing-user': {
+            args: { userId: 'missing' },
+            shouldThrow: true
+          }
+        },
+        timeout: 5000
+      }
+    );
+
+    expect(results.failed).toBe(0);
+    expect(results.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "Tool 'get-profile:missing-user' execution",
+          status: 'pass'
+        })
+      ])
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    include: ['src/__tests__/**/*.test.ts'],
+    include: ['src/__tests__/**/*.test.ts', 'examples/**/*.test.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],


### PR DESCRIPTION
## Summary
- add `examples/async-tools.test.ts` showing an async MCP tool handler with a mocked async dependency
- cover both the successful async result path and an expected async error path
- include example tests in Vitest and link the example from the README

Closes #47

## Verification
- `npx vitest run examples/async-tools.test.ts` -> 2 tests passed
- `npm test` -> 5 files / 62 tests passed
- `npm run lint` -> passed
- `npm run build` -> passed