### PR TITLE
Add production-ready Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+# Multi-stage Dockerfile for mcp-jest
+# Stage 1: Build
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm ci
+
+# Copy source code
+COPY . .
+
+# Build the project
+RUN npm run build
+
+# Stage 2: Production
+FROM node:20-alpine
+
+# Install dumb-init for proper signal handling
+RUN apk add --no-cache dumb-init
+
+# Create non-root user
+RUN addgroup -g 1001 -S mcpjest && \
+    adduser -S -u 1001 -G mcpjest mcpjest
+
+WORKDIR /app
+
+# Copy built artifacts and necessary files from builder
+COPY --from=builder --chown=mcpjest:mcpjest /app/dist ./dist
+COPY --from=builder --chown=mcpjest:mcpjest /app/package*.json ./
+COPY --from=builder --chown=mcpjest:mcpjest /app/README.md ./
+COPY --from=builder --chown=mcpjest:mcpjest /app/llms.txt ./
+COPY --from=builder --chown=mcpjest:mcpjest /app/llms-full.txt ./
+
+# Install production dependencies only
+RUN npm ci --only=production && \
+    npm cache clean --force
+
+# Switch to non-root user
+USER mcpjest
+
+# Make CLI executable globally available
+ENV PATH="/app/dist:${PATH}"
+
+# Healthcheck - verify the CLI is accessible
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD node -e "require('./dist/cli.js')" || exit 1
+
+# Default command: show help
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["node", "/app/dist/cli.js", "--help"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3.8'
+
+services:
+  mcp-jest:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: mcp-jest:latest
+    container_name: mcp-jest
+
+    # Mount your MCP server and test files
+    volumes:
+      - ./tests:/tests:ro
+      - ./examples:/examples:ro
+
+    # Override default command to run tests
+    command: ["node", "/app/dist/cli.js"]
+
+    # Environment variables (customize as needed)
+    environment:
+      - NODE_ENV=production
+
+    # Resource limits (optional)
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 512M
+        reservations:
+          cpus: '0.5'
+          memory: 256M
+
+    # Restart policy
+    restart: unless-stopped
+
+    # Security options
+    security_opt:
+      - no-new-privileges:true
+
+    # Read-only root filesystem (uncomment if your tests don't need write access)
+    # read_only: true
+
+    # Temporary filesystem for /tmp if using read-only root
+    # tmpfs:
+    #   - /tmp


### PR DESCRIPTION
Production-ready Dockerfile and docker-compose.yml for mcp-jest.

**Dockerfile features:**
- Multi-stage build (builder + production)
- Non-root user (mcpjest:1001)
- Healthcheck for CLI availability
- dumb-init for proper signal handling
- Production dependencies only

**docker-compose.yml features:**
- Resource limits (CPU/memory)
- Security options (no-new-privileges)
- Volume mounts for tests and examples
- Sensible defaults

Addresses the production-readiness checklist for mcp-jest.