### PR TITLE
Release candidate: mcp-jest v1.0.0

### DIFF
--- a/RELEASE-NOTES-v1.0.0.md
+++ b/RELEASE-NOTES-v1.0.0.md
@@ -1,0 +1,50 @@
+# MCP-Jest v1.0.0 - Initial Release
+
+**First stable release of MCP-Jest** — a testing framework for Model Context Protocol (MCP) servers.
+
+## What's Included
+
+### Core Features
+- **MCP Server Testing Framework**: Like Jest, but specifically designed for MCP servers
+- **Test Discovery**: Automatic detection of `.mcp-test.js` files
+- **Built-in Reporters**: Colorized test output with pass/fail indicators
+- **Schema Validator**: Validates MCP server responses against protocol specifications
+- **Test Filtering**: `--filter` and `--skip` flags for selective test execution
+
+### Infrastructure
+- **Docker Support**: Production-ready multi-stage Dockerfile with non-root user and healthcheck
+- **CI/CD**: GitHub Actions workflow testing on Node.js 20.x, 21.x, 22.x across Ubuntu, Windows, macOS
+- **LLM Discoverability**: `llms.txt` and `llms-full.txt` for AI-assisted development
+
+### Streamable HTTP
+- Support for HTTP-based MCP servers with streaming responses
+- Built on MCP SDK 1.12.1
+
+## Installation
+
+```bash
+npm install -g mcp-jest
+```
+
+## Usage
+
+```bash
+# Run all MCP tests
+mcp-jest
+
+# Run with filtering
+mcp-jest --filter "specific test pattern"
+mcp-jest --skip "tests to exclude"
+```
+
+## Docker
+
+```bash
+docker pull reallyartificial/mcp-jest:latest
+docker run --rm -v $(pwd):/workspace mcp-jest
+```
+
+---
+
+**Full Changelog**: Initial release
+**Contributors**: @josharsh, @fridayjoshi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-jest",
-  "version": "1.2.1",
+  "version": "1.0.0",
   "description": "Testing framework for Model Context Protocol (MCP) servers - like Jest but for MCP",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Initial Release Candidate

This is the **first stable release** of mcp-jest, a testing framework for Model Context Protocol (MCP) servers.

### What Changed
- ✅ Bumped version from 1.2.1 → 1.0.0 (semantic versioning reset for first official release)
- 📝 Added RELEASE-NOTES-v1.0.0.md with feature summary

### Core Features Shipping
- MCP server testing framework with discovery, reporters, validators
- Test filtering (`--filter`, `--skip`)
- Streamable HTTP support
- Production-ready Docker + CI (Node 20/21/22)

### Uncertain
- **npm scope**: Package currently uses `mcp-jest` but repo is under `@reallyartificial` org. Should we publish as `@reallyartificial/mcp-jest`?
- **First release version**: Using 1.0.0 instead of package.json's 1.2.1. Open to changing if there's a reason to preserve the higher version.

### Next Steps
- Merge this PR
- Create GitHub release v1.0.0
- Publish to npm (pending scope decision)

---
**Commit**: 74b0925
**Branch**: release/v1.0.0